### PR TITLE
update hardcoded imports for ferovinum new structure

### DIFF
--- a/haskell/compiler/adlc-lib1/ADL/Compiler/Backends/JavaTables/V1.hs
+++ b/haskell/compiler/adlc-lib1/ADL/Compiler/Backends/JavaTables/V1.hs
@@ -56,12 +56,12 @@ generateJavaModelV1 jtflags cgp javaPackageFn mod (decl,struct,table,dbTableAnno
     dbTableNameT = dbTableName decl
     gen = do
       rtPackage <- J.getRuntimePackage
-      J.addImport "au.com.helixta.nofrills.sql.Dsl"
-      J.addImport "au.com.helixta.nofrills.sql.Dsl.Table"
-      J.addImport "au.com.helixta.nofrills.sql.Dsl.FieldRef"
-      J.addImport "au.com.helixta.nofrills.sql.Dsl.TypedField"
-      J.addImport "au.com.helixta.nofrills.sql.impl.DbResults"
-      J.addImport "au.com.helixta.util.sql.QueryHelper"
+      J.addImport "common.nofrills.sql.Dsl"
+      J.addImport "common.nofrills.sql.Dsl.Table"
+      J.addImport "common.nofrills.sql.Dsl.FieldRef"
+      J.addImport "common.nofrills.sql.Dsl.TypedField"
+      J.addImport "common.nofrills.sql.impl.DbResults"
+      J.addImport "common.util.sql.QueryHelper"
       J.addImport (J.javaClass rtPackage "JsonBindings")
       J.addImport "com.google.common.collect.ImmutableMap"
       J.addImport "com.google.common.collect.Maps"
@@ -72,7 +72,7 @@ generateJavaModelV1 jtflags cgp javaPackageFn mod (decl,struct,table,dbTableAnno
       J.addImport "java.util.Optional"
       J.addImport "java.util.function.Function"
       J.addImport "java.util.function.Supplier"
-      J.addImport "au.com.helixta.util.common.collect.Mapx"
+      J.addImport "common.util.common.collect.Mapx"
 
       J.addMethod (ctemplate "public static final $1 $2 = new $1();" [tableClassNameT, tableInstanceNameT])
 

--- a/haskell/compiler/adlc-lib1/ADL/Compiler/Backends/JavaTables/V2.hs
+++ b/haskell/compiler/adlc-lib1/ADL/Compiler/Backends/JavaTables/V2.hs
@@ -35,7 +35,7 @@ generateClassWithIdPrimaryKey jtflags cgp javaPackageFn mod dbtable = execState 
     gen = do
       generateClassCommon dbtable
 
-      J.addImport "au.com.helixta.adl.util.AdlTableWithId"
+      J.addImport "common.adl.util.AdlTableWithId"
 
       adlColumns <- mkAdlColumns cgp dbtable (SC.table_columns table) (AST.s_fields struct)
 
@@ -106,7 +106,7 @@ generateClass jtflags cgp javaPackageFn mod dbtable = execState gen state0
     gen = do
       generateClassCommon dbtable
 
-      J.addImport "au.com.helixta.adl.util.AdlTable"
+      J.addImport "common.adl.util.AdlTable"
 
       adlColumns <- mkAdlColumns cgp dbtable (SC.table_columns table) (AST.s_fields struct)
 
@@ -172,12 +172,12 @@ generateClassCommon dbtable  = do
   let (tableClassNameT,tableInstanceNameT,javaClassNameT,dbTableNameT) = mkNames dbtable
 
   rtPackage <- J.getRuntimePackage
-  J.addImport "au.com.helixta.adl.custom.DbKey"
-  J.addImport "au.com.helixta.adl.common.db.WithDbId"
-  J.addImport "au.com.helixta.adl.util.AdlField"
-  J.addImport "au.com.helixta.adl.util.DbConversions"
-  J.addImport "au.com.helixta.nofrills.sql.Dsl"
-  J.addImport "au.com.helixta.nofrills.sql.impl.DbResults"
+  J.addImport "common.adl.custom.DbKey"
+  J.addImport "common.adl.common.db.WithDbId"
+  J.addImport "common.adl.util.AdlField"
+  J.addImport "common.adl.util.DbConversions"
+  J.addImport "common.nofrills.sql.Dsl"
+  J.addImport "common.nofrills.sql.impl.DbResults"
   J.addImport (J.javaClass rtPackage "JsonBindings")
   J.addImport (J.javaClass rtPackage "JsonBinding")
   J.addImport "javax.annotation.Nullable"


### PR DESCRIPTION
Summary of changes:
- Updates hard-coded imports in the adl haskell code to generate java database tables classes.
- This is due to code cleanup and structure changes done in https://github.com/ferovinum/ferovinum/pull/2600

